### PR TITLE
Fix content position bug

### DIFF
--- a/src/app/shared/side-menu/side-menu.component.scss
+++ b/src/app/shared/side-menu/side-menu.component.scss
@@ -23,3 +23,7 @@
 .entity-menu-accordion{
   background-color: #f4f4f4;
 }
+
+#sideMenuAccordion {
+  width: 300px;
+}


### PR DESCRIPTION
* Implementation of hidding unauthorized elements caused the sidemenu to
not have any items at the start of the application. Because of that, the
side menu had 0 width and the material component computed wrongly the
needed margin for the content.
* Solution is to set static width to the side menu.